### PR TITLE
Remove invalid assert

### DIFF
--- a/lib/protocol/connection.js
+++ b/lib/protocol/connection.js
@@ -323,8 +323,7 @@ priority_loop:
         var moreNeeded = this.push(frame);
         this._changeStreamCount(frame.count_change);
 
-        assert(moreNeeded !== null); // The frame shouldn't be unforwarded
-        if (moreNeeded === false) {
+        if (!moreNeeded) {
           break priority_loop;
         }
       }


### PR DESCRIPTION
Fixes node-apn/node-apn#471 and molnarg/node-http2#228

In the case where this._push(frame) returns null (i.e., the frame is too
large for the window and split or the window size is <=0), moreNeeded
will be set to null. Then this._queue.push(frame) is called, but
moreNeeded is still null. Thus, any time the window is <=0 or the frame
is split we'll hit the assert:
```
  var moreNeeded = null;
  if (this._queue.length === 0) {
    moreNeeded = this._push(frame);
  }

  if (moreNeeded === null) {
    this._queue.push(frame);
  }

  return moreNeeded;
```

Credit goes to @jrabek for original version of this patch